### PR TITLE
twitter認証方法変更

### DIFF
--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,7 +1,7 @@
 import { getApps, initializeApp } from "firebase/app";
 import {
   getAuth,
-  signInWithRedirect,
+  signInWithPopup,
   TwitterAuthProvider,
   signOut,
   onAuthStateChanged as onFirebaseAuthStateChanged,
@@ -37,7 +37,7 @@ export const auth = getAuth();
 const twitterProvider = new TwitterAuthProvider();
 
 export const login = (): void => {
-  signInWithRedirect(auth, twitterProvider);
+  signInWithPopup(auth, twitterProvider);
 };
 
 export const logout = () => {


### PR DESCRIPTION
Firebase Authenticationで`signInWithRedirect`を使ったTwitterログインができなくなったので、暫定対応として`signInWithPopup`に変更
参考：https://mackee.hatenablog.com/entry/perl-advent-calendar-2022-day9